### PR TITLE
chore: bump widget version & use darkmode switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
   ],
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@0xsquid/widget": "1.4.25",
+    "@0xsquid/widget": "1.4.31",
     "@arcxmoney/analytics": "^1.6.1",
     "@coinbase/cbpay-js": "^1.6.0",
     "@cryption/df-sdk-core": "0.0.8",

--- a/src/pages/SwapPage/SwapCrossChain.tsx
+++ b/src/pages/SwapPage/SwapCrossChain.tsx
@@ -1,19 +1,64 @@
 import { SquidWidget } from '@0xsquid/widget';
+import { ConfigTheme } from '@0xsquid/widget/widget/core/types/config';
 import { Box, Grid } from '@material-ui/core';
 import React, { useEffect } from 'react';
+import { useIsDarkMode } from 'state/user/hooks';
 
 const SwapCrossChain: React.FC = () => {
+  const darkMode = useIsDarkMode();
+  const darkModeStyle: ConfigTheme = {
+    baseContent: '#f3ecec',
+    neutralContent: '#696c80',
+    base100: '#0f0e0e',
+    base200: '#232531',
+    base300: '#0f1720',
+    error: '#ED6A5E',
+    warning: '#FFB155',
+    success: '#62C555',
+    primary: '#558AC5',
+    secondary: '#457cbb',
+    secondaryContent: '#2e2d30',
+    neutral: '#121319',
+    roundedBtn: '26px',
+    roundedBox: '1rem',
+    roundedDropDown: '20rem',
+    displayDivider: true,
+  };
+  const lightModeStyle: ConfigTheme = {
+    baseContent: '#070002',
+    neutralContent: '#070002',
+    base100: '#FFFFFF',
+    base200: '#e7e7e7',
+    base300: '#FBF5FF',
+    error: '#ED6A5E',
+    warning: '#FFB155',
+    success: '#62C555',
+    primary: '#558AC5',
+    secondary: '#457cbb',
+    secondaryContent: '#F7F6FB',
+    neutral: '#FFFFFF',
+    roundedBtn: '26px',
+    roundedBox: '1rem',
+    roundedDropDown: '20rem',
+    displayDivider: true,
+  };
   useEffect(() => {
     console.log('SwapCrossChain #init');
   }, []);
 
   return (
-    <Grid style={{ display: 'flex' }}>
-      <Box style={{ marginLeft: 'auto', marginRight: 'auto' }}>
+    <Grid style={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
+      <Box
+        style={{
+          width: '100%',
+          maxWidth: '420px',
+        }}
+      >
         <SquidWidget
           config={{
             companyName: 'Quickswap',
             apiUrl: 'https://api.0xsquid.com',
+            style: darkMode ? darkModeStyle : lightModeStyle,
           }}
         />
       </Box>

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,10 +239,10 @@
     ethers "^5.7.1"
     release-it "^15.5.0"
 
-"@0xsquid/widget@1.4.25":
-  version "1.4.25"
-  resolved "https://registry.yarnpkg.com/@0xsquid/widget/-/widget-1.4.25.tgz#f9d750aec182cea8580e37be03fdc1b2e2340a0c"
-  integrity sha512-XRvqe0gRfxmlnsJd6fpxZk0oEa95kfSFyqM+UAKaJEpJ76fdlXoT0Y3jvlwidjpP81XGpdWr9IhW/h8sJoTEGg==
+"@0xsquid/widget@1.4.31":
+  version "1.4.31"
+  resolved "https://registry.yarnpkg.com/@0xsquid/widget/-/widget-1.4.31.tgz#26e7ca4694760cdc764453c714af73dacb3b0b28"
+  integrity sha512-95J2w7w0yU+9/vkmX6X0Dc168+bsGbq4k/KpIKVNCGCyZsqUwZU0yUVBQtEk7CZfleNhJQsGduqPFqAahI+iCg==
   dependencies:
     "@0xsquid/sdk" "^1.3.9"
     "@cosmjs/stargate" "^0.29.2"


### PR DESCRIPTION
- using the latest widget version that fixes CSS conflicts
- centering the widget inside the container
- prepare for darkmode/lightmode switch

The current themes are made using quickswap colors, but you can of course update them